### PR TITLE
Add automatic versioning and release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,4 +20,5 @@ jobs:
       - id: type
         shell: bash
         run: |
+          
           echo ${{ steps.pr.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 
 on:
-  pull_request: {}
-
+  push:
+    branches: [ main ]
 jobs:
   generate-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: Release
 
-on: workflow_dispatch
+on:
+  pull_request: {}
 
 jobs:
   generate-version:
@@ -20,5 +21,7 @@ jobs:
       - id: type
         shell: bash
         run: |
-          
-          echo ${{ steps.pr.outputs.labels }}
+          if [[ " ${${{ steps.pr.outputs.labels }}[*]} " =~ " bug " ]]; then
+            echo "Found"
+          fi
+          echo "not found"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,25 @@ jobs:
       - id: type
         shell: bash
         run: |
-          
-          if [[ "${{ steps.pr.outputs.labels }}" =~ "bug" ]]; then
-            echo "Found"
+          if [[ "${{ steps.pr.outputs.labels }}" =~ "major" ]]; then
+            echo "::set-output name=pr-type::major"
+            exit 0
+          elif [[ "${{ steps.pr.outputs.labels }}" =~ "minor" ]]; then
+            echo "::set-output name=pr-type::minor"
+            exit 0
+          elif [[ "${{ steps.pr.outputs.labels }}" =~ "patch" ]]; then
+            echo "::set-output name=pr-type::patch"
+            exit 0
           fi
-          echo "not found"
+          echo "Failed: No supported label found in '${{ steps.pr.outputs.labels }}'." 
+          exit 1
+
+      - uses: zwaldowski/semver-release-action@v2
+        with:
+          dry_run: true
+          bump: ${{ steps.type.outputs.pr-type }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set version output
+        id: out
+        run: echo "::set-output name=version::$(echo ${VERSION})"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
       - id: type
         shell: bash
         run: |
-          if [[ " ${${{ steps.pr.outputs.labels }}[*]} " =~ " bug " ]]; then
+          
+          if [[ " ${'${{ steps.pr.outputs.labels }}'[*]} " =~ "bug" ]]; then
             echo "Found"
           fi
           echo "not found"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,3 +43,34 @@ jobs:
       - name: Set version output
         id: out
         run: echo "::set-output name=version::$(echo ${VERSION})"
+
+  build:
+    needs: [ "generate-version" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GIT_ACTION_TOKEN }}
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - run: mvn versions:set -DnewVersion=${{ needs.generate-version.outputs.version }}
+
+  git-release:
+    needs: [ "generate-version", "build"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ needs.generate-version.outputs.version }}
+          prerelease: false
+          title: ${{ needs.generate-version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GIT_ACTION_TOKEN }}
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,32 +3,21 @@ name: Release
 on: workflow_dispatch
 
 jobs:
-  build:
+  generate-version:
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.out.outputs.version }}
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+
+      - id: pr
+        uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
         with:
-          token: ${{ secrets.GIT_ACTION_TOKEN }}
-      - uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      - uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: maven
-          server-id: sonatype-nexus
-          server-username: SERVER_USERNAME
-          server-password: SERVER_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
-      - run: mvn -B -ntp dependency:go-offline
-      - run: mvn -B -ntp release:prepare
-      - run: mvn -B -ntp release:perform
-        env:
-          SERVER_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SERVER_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: type
+        shell: bash
+        run: |
+          echo ${{ steps.pr.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           
-          if [[ " ${'${{ steps.pr.outputs.labels }}'[*]} " =~ "bug" ]]; then
+          if [[ "${{ steps.pr.outputs.labels }}" =~ "bug" ]]; then
             echo "Found"
           fi
           echo "not found"


### PR DESCRIPTION
@sschnabe As talked about yesterday, this adds a label-based automatic versioning process:
* patch: 0.0.x+1
* minor: 0.x+1.0
* major. x+1.0.0
It also automatically releases(using the process already in place) the plugin and create a new github release. The release notes will be generated out of the commit-messages, thus squash-merging makes the notes more readable;)