### PR TITLE
Remove duplicate bouncycastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,12 @@
 		<dependency>
 			<groupId>com.github.docker-java</groupId>
 			<artifactId>docker-java-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcpkix-jdk15on</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.github.docker-java</groupId>


### PR DESCRIPTION
bc is provided by docker client as `bcpkix-jdk15on` and kubernetes client as `bcpkix-jdk18on`, this commits removes the older implementation