### PR TITLE
Set version for transitive dependencies with issues from SBOM report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,28 @@
 				<version>${version.org.projectlombok}</version>
 			</dependency>
 
+			<!-- transitive dependencies with issues -->
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.11.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.15.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.15.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>31.1-jre</version>
+			</dependency>
+
 			<!-- test -->
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
see https://sbom.lift.sonatype.com/report/T1-118f0f57da8c6b3097cc-57a3aafcc544f-1683704084-c8d8af832f0e4bf39a408c9dea049a8d

Upstream repo is not very well maintained: https://github.com/docker-java/docker-java/pull/1957