### PR TITLE
Move await sa to kubectl goal

### DIFF
--- a/src/main/java/io/kokuwa/maven/k3s/mojo/KubectlMojo.java
+++ b/src/main/java/io/kokuwa/maven/k3s/mojo/KubectlMojo.java
@@ -117,6 +117,10 @@ public class KubectlMojo extends K3sMojo {
 			}
 		}
 
+		// wait for service account, see https://github.com/kubernetes/kubernetes/issues/66689
+
+		Await.await(getLog(), "k3s service account ready").until(getKubernetesClient()::isServiceAccountReady);
+
 		// execute command
 
 		getLog().info("Execute: " + command);

--- a/src/main/java/io/kokuwa/maven/k3s/mojo/StartMojo.java
+++ b/src/main/java/io/kokuwa/maven/k3s/mojo/StartMojo.java
@@ -125,10 +125,6 @@ public class StartMojo extends K3sMojo {
 
 		Await.await(getLog(), "k3s master node ready").until(kubernetes::isNodeReady);
 
-		// wait for service account, see https://github.com/kubernetes/kubernetes/issues/66689
-
-		Await.await(getLog(), "k3s service account ready").until(kubernetes::isServiceAccountReady);
-
 		// wait for pods get ready
 
 		if (podWait) {


### PR DESCRIPTION
SA is only needed for kubectl. If using image goal this could save 10 seconds per run.