### PR TITLE
Apply `pullTimeout` for `k3s:image` to allow long running imports.

### DIFF
--- a/src/main/java/io/kokuwa/maven/k3s/mojo/ImageMojo.java
+++ b/src/main/java/io/kokuwa/maven/k3s/mojo/ImageMojo.java
@@ -156,7 +156,7 @@ public class ImageMojo extends K3sMojo {
 			var outputPattern = Pattern.compile("^unpacking (?<image>.*) \\(sha256:[0-9a-f]{64}\\).*$");
 
 			getDocker().copyToContainer(tarFile, destination);
-			for (var output : getDocker().exec("ctr", "image", "import", destination.toString())) {
+			for (var output : getDocker().exec(pullTimeout, "ctr", "image", "import", destination.toString())) {
 				var matcher = outputPattern.matcher(output);
 				if (matcher.matches()) {
 					getDocker().exec("ctr", "image", "label", matcher.group("image"), labelPath + "=" + tarFile);
@@ -234,7 +234,7 @@ public class ImageMojo extends K3sMojo {
 		try {
 			getDocker().saveImage(image, source);
 			getDocker().copyToContainer(source, destination);
-			getDocker().exec("ctr", "image", "import", destination.toString());
+			getDocker().exec(pullTimeout, "ctr", "image", "import", destination.toString());
 			getDocker().exec("ctr", "image", "label", normalizedImage, label + "=" + digest);
 		} catch (MojoExecutionException e) {
 			getLog().error("Failed to import tar " + source, e);


### PR DESCRIPTION
Also