### PR TITLE
feat(apply): add namespace parameter to k3s:apply goal

### DIFF
--- a/docs/goal/apply.md
+++ b/docs/goal/apply.md
@@ -6,5 +6,6 @@ Runs kubectl to apply manifests.
 | ----------- | --------------- | -------------------------------------------------------------------------------------- | ------------ |
 | `manifests` | `k3s.manifests` | Path where to find manifest files to apply. This files are copied to docker container. | src/test/k3s |
 | `subdir`    | `k3s.subdir`    | Subdir of **manifests** to execute.                                                    | `null`       |
+| `namespace` | `k3s.namespace` | Namespace to use when applying manifests. If not set, the namespace from the manifests is used. | `null` |
 | `timeout`   | `k3s.timeout`   | Timeout in seconds to wait for resources getting ready.                                | 300          |
 | `skipApply` | `k3s.skipApply` | Skip applying kubectl manifests.                                                       | false        |

--- a/src/main/java/io/kokuwa/maven/k3s/mojo/ApplyMojo.java
+++ b/src/main/java/io/kokuwa/maven/k3s/mojo/ApplyMojo.java
@@ -69,6 +69,14 @@ public class ApplyMojo extends K3sMojo {
 	private Duration timeout;
 
 	/**
+	 * Namespace to use when applying manifests. If not set, the default namespace from the manifests is used.
+	 *
+	 * @since 1.6.0
+	 */
+	@Parameter(property = "k3s.namespace")
+	private String namespace;
+
+	/**
 	 * Skip applying kubectl manifests.
 	 *
 	 * @since 1.0.0
@@ -169,6 +177,9 @@ public class ApplyMojo extends K3sMojo {
 		var command = new ArrayList<String>();
 		command.add("kubectl");
 		command.add("apply");
+		if (namespace != null) {
+			command.add("--namespace=" + namespace);
+		}
 		if (kustomize) {
 			command.add("--kustomize=" + subPath);
 		} else {
@@ -256,6 +267,10 @@ public class ApplyMojo extends K3sMojo {
 
 	public void setTimeout(int timeout) {
 		this.timeout = Duration.ofSeconds(timeout);
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
 	}
 
 	public void setSkipApply(boolean skipApply) {

--- a/src/test/java/io/kokuwa/maven/k3s/mojo/ApplyMojoTest.java
+++ b/src/test/java/io/kokuwa/maven/k3s/mojo/ApplyMojoTest.java
@@ -115,4 +115,14 @@ public class ApplyMojoTest extends AbstractTest {
 		assertDoesNotThrow(runMojo::execute);
 		assertDoesNotThrow(applyMojo::execute);
 	}
+
+	@DisplayName("with namespace")
+	@Test
+	void withNamespace(RunMojo runMojo, ApplyMojo applyMojo) {
+		applyMojo.setSubdir("deploymentInNamespace");
+		applyMojo.setNamespace("test-namespace");
+		assertDoesNotThrow(runMojo::execute);
+		exec("kubectl", "create", "namespace", "test-namespace");
+		assertDoesNotThrow(applyMojo::execute);
+	}
 }

--- a/src/test/k3s/deploymentInNamespace/deployment.yaml
+++ b/src/test/k3s/deploymentInNamespace/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: echo-deployment
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: echo-deployment
+    spec:
+      containers:
+        - name: echo
+          image: jmalloc/echo-server:0.3.1
+          ports:
+            - name: http
+              containerPort: 8080
+          startupProbe:
+            periodSeconds: 1
+            httpGet:
+              path: /
+              port: http
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 0


### PR DESCRIPTION
## Problem

When using `k3s:apply` to deploy manifests, it was not possible to specify
a target Kubernetes namespace via plugin configuration. Users who wanted to
deploy resources into a namespace other than `default` had to include an
explicit `namespace:` field in every manifest file or use a kustomization
with `namespace:` set. There was no way to override the namespace from the
Maven configuration or command line.

## Solution

Add a new optional `namespace` parameter to the `k3s:apply` goal. When set,
it is passed as `--namespace=<value>` to the `kubectl apply` command, so all
resources in the manifests that do not declare an explicit namespace will be
deployed into the specified namespace.

The parameter is exposed as:
- Maven property: `k3s.namespace`
- POM configuration: `<namespace>my-namespace</namespace>`
- CLI: `-Dk3s.namespace=my-namespace`

If not set, the behaviour is identical to before (namespace comes from the
manifests themselves).

## Changes

- `ApplyMojo`: new `namespace` parameter + `--namespace` flag in `kubectl apply`
- `ApplyMojoTest`: new test `withNamespace` that creates a custom namespace
  and verifies the deployment is applied to it
- `src/test/k3s/deploymentInNamespace/`: test manifest (deployment without
  explicit namespace)
- `docs/goal/apply.md`: documented the new parameter